### PR TITLE
Simplify test workflow

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -5,9 +5,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**.py'
+      - '.github/workflows/test_suite.yml'
 
   # Run test suite whenever commits are pushed to an open PR
   pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/test_suite.yml'
 
   # Run test suite every Sunday at 1AM
   schedule:
@@ -16,13 +22,3 @@ on:
 jobs:
   test_suite:
     uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main
-    with:
-      install-command: 'python -m pip install -e .'
-      test-command: |
-        export GITHUB_ACTIONS_TEST_RUN=1
-        python $(which firedrake-clean)
-        python -m coverage erase
-        python -m coverage run --source=opt_adapt -m pytest -v --durations=20 test
-        python -m coverage report
-      changed-files-patterns: |
-        **/*.py


### PR DESCRIPTION
The reusable workflow is no longer valid for how opt-adapt is set up
https://github.com/mesh-adaptation/opt_adapt/actions/runs/12335156065

This PR applies the same simplifications as in the other packages to get things working again.